### PR TITLE
Bump to 1.0.2

### DIFF
--- a/deface.gemspec
+++ b/deface.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "deface"
-  s.version = "1.0.0"
+  s.version = "1.0.2"
 
   s.authors = ["Brian D Quinn"]
   s.description = "Deface is a library that allows you to customize ERB, Haml and Slim views in a Rails application without editing the underlying view."


### PR DESCRIPTION
1.0.1 was released to rubygems but not bumped in the repo, so skipping
that version.
