### PR TITLE
Allow Nokogiri versions beyond minor version 1.6

### DIFF
--- a/deface.gemspec
+++ b/deface.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.summary = "Deface is a library that allows you to customize ERB, Haml and Slim views in Rails"
 
-  s.add_dependency('nokogiri', '~> 1.6.0')
+  s.add_dependency('nokogiri', '~> 1.6')
   s.add_dependency('rails', '>= 3.1')
   s.add_dependency('colorize', '>= 0.5.8')
   s.add_dependency('polyglot')


### PR DESCRIPTION
This PR relaxes the dependency on the Nokogiri gem from being tied to patch releases in the 1.6.x series, to allow use of minor releases in the 1.x series - so we can upgrade Spree 2.4 stores against the vulnerabilities [1] published against Nokogiri in the 1.6 and 1.7 series.

```
    spree_digital was resolved to 1.1.1, which depends on
      spree_core (~> 2.4.0) was resolved to 2.4.10, which depends on
        deface (~> 1.0.0) was resolved to 1.0.0, which depends on
          nokogiri (~> 1.6.0)
```

1. https://github.com/sparklemotion/nokogiri/blob/1fa9d1853a6ca0a20c8086907318263022d5a42c/CHANGELOG.md