### PR TITLE
Set haml dependency to version less than 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 script: "bundle exec rake"
 rvm:
-  - 1.9.3
   - 2.0.0
+  - 2.1
 gemfile:
   - gemfiles/rails3_1.gemfile
   - gemfiles/rails3_2.gemfile

--- a/deface.gemspec
+++ b/deface.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency('polyglot')
 
   s.add_development_dependency('rspec', '>= 3.1.0')
-  s.add_development_dependency('haml', '>= 3.1.4')
+  s.add_development_dependency('haml', '>= 3.1.4', '< 5.0')
   s.add_development_dependency('slim', '>= 2.0.0') # 2.0.1 breaks slim loader specs
   s.add_development_dependency('simplecov', '>= 0.6.4')
   s.add_development_dependency('generator_spec', '~> 0.8')


### PR DESCRIPTION
Trying to get this gem to build, it seems the `plugin.rb` file from HAML, used in `spec_helper.rb` has been moved in version 5.0 and up.

Initially, I updated the path and haml dependency to 5.0, but noticed in the haml changelog, [Rails 3 support is dropped](https://github.com/haml/haml/blob/master/CHANGELOG.md#500).

Update:

The current version of slim requires Ruby 2.0 or greater.
