### PR TITLE
Allow nokogiri dependency update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 script: "bundle exec rake"
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - 2.1
+  - 2.2
 gemfile:
   - gemfiles/rails3_1.gemfile
   - gemfiles/rails3_2.gemfile

--- a/deface.gemspec
+++ b/deface.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.summary = "Deface is a library that allows you to customize ERB, Haml and Slim views in Rails"
 
-  s.add_dependency('nokogiri', '~> 1.6.0')
+  s.add_dependency('nokogiri', '~> 1.6')
   s.add_dependency('rails', '>= 3.1')
   s.add_dependency('colorize', '>= 0.5.8')
   s.add_dependency('polyglot')


### PR DESCRIPTION
Preface: will need #7 to pass build on travis.

Second attempt at relaxing the dependency on Nokogiri to allow a version update beyond the 1.6 branch, which still seems to have a [known CVE against it](sparklemotion/nokogiri#1634).