### PR TITLE
Update Ruby version for build to 2.1 and 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 script: "bundle exec rake"
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - 2.1.0
+  - 2.2.0
 gemfile:
   - gemfiles/rails3_1.gemfile
   - gemfiles/rails3_2.gemfile


### PR DESCRIPTION
Related to #7 and #8, replacing Ruby version 1.9.3 and 2.0 with 2.1 and 2.2 for travis builds.

Recent releases of dependencies (slim, nokogiri) requiring later version of Ruby as a minimum. Even though 2.1 is [eol](https://www.ruby-lang.org/en/downloads/branches/), it's pretty recent.